### PR TITLE
Enabling ZFS_DEBUG flag in debug build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ cscope.*
 *.[oa]
 *.lo
 *.la
+*.i
+*.s
 *.mod.c
 *~
 *.swp

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,4 @@
 ACLOCAL_AMFLAGS= -I m4
 AUTOMAKE_OPTIONS = foreign
 
-DEFAULT_INCLUDES = -include ${top_builddir}/config.h
-
 SUBDIRS = src include

--- a/m4/debug.m4
+++ b/m4/debug.m4
@@ -7,7 +7,8 @@ AC_DEFUN([CSTOR_AC_DEBUG], [
 		[enable_debug=no])
 
     AS_IF([test "x$enable_debug" == xyes], [
-        DEBUG_FLAGS=-DDEBUG
+        DEBUG_FLAGS="-DDEBUG -Werror"
+        AC_DEFINE(ZFS_DEBUG, 1, [libcstor debugging enabled])
     ],[
         DEBUG_FLAGS=-DNDEBUG
     ])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,9 @@ AM_CPPFLAGS=-D_GNU_SOURCE
 
 lib_LTLIBRARIES = libcstor.la
 
-DEFAULT_INCLUDES = -I../include	\
+DEFAULT_INCLUDES =	\
+	-include ${top_builddir}/config.h	\
+	-I../include	\
 	${SPL_SRC} 	\
 	${ZFS_SRC}
 


### PR DESCRIPTION
Changes:
- Enabling `ZFS_DEBUG` flag in debug build

Signed-off-by: mayank <mayank.patel@cloudbyte.com>