### PR TITLE
docs(contributor): add governance and maintainers files

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,2 @@
+This is a OpenEBS sub project and abides by the 
+[OpenEBS Project Governance](https://github.com/openebs/openebs/blob/master/GOVERNANCE.md).

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,19 @@
+# Official list of OpenEBS Maintainers.
+#
+# Names added to this file should be in the following format:
+#     Individual's name,@githubhandle, Company Name
+#
+# Please keep the below list sorted in ascending order.
+#
+#Maintainers
+"Jeffry Molanus",@gila,MayaData
+"Kiran Mova",@kmova,MayaData
+"Richard Elling",@richardelling,Viking Enterprise Solutions a division of Sanmina Corporation
+"Vishnu Itta",@vishnuitta,MayaData
+
+#Reviewers
+"Jan Kryl",@jkryl,MayaData
+"Mayank Patel",@mynktl,MayaData
+"Pawan Prakash",@pawanpraka1,MayaData
+"Payes Anand",@payes,MayaData
+"Satbir Singh",@satbirchhikara,MayaData

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,5 @@
+The source code developed for the OpenEBS Project is licensed under Apache 2.0. 
+
+However, the OpenEBS project contains unmodified/modified subcomponents from other Open Source Projects with separate copyright notices and license terms. 
+
+Your use of the source code for these subcomponents is subject to the terms and conditions as defined by those source projects.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # libcstor
+[![Build Status](https://travis-ci.org/openebs/cstor.svg?branch=develop)](https://travis-ci.org/openebs/cstor)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fopenebs%2Flibcstor.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fopenebs%2Flibcstor?ref=badge_shield)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2765/badge)](https://bestpractices.coreinfrastructure.org/projects/2765)
 
 library to serve IOs on ZVOL over network connections
 


### PR DESCRIPTION
This PR adds the current maintainer and reviewer list
for the openebs/maya project. Also links to the Governance
process outlined for the overall openebs projects in openebs/openebs#2547

Signed-off-by: kmova <kiran.mova@openebs.io>