### PR TITLE
fix(stale_snaps): cherry-pick to delete internal created snaps for helping in rebuild during data connection

### DIFF
--- a/include/data_conn.h
+++ b/include/data_conn.h
@@ -71,8 +71,6 @@ int uzfs_zvol_create_internal_snapshot(zvol_state_t *zv, zvol_state_t **snap_zv,
 void signal_fds_related_to_zinfo(zvol_info_t *zinfo);
 void quiesce_wait(zvol_info_t *zinfo);
 
-int uzfs_zvol_create_internal_snapshot(zvol_state_t *zv, zvol_state_t **snap_zv,
-    uint64_t io_num);
 int uzfs_zvol_handle_rebuild_snap_done(zvol_io_hdr_t *, int, zvol_info_t *);
 
 #ifdef __cplusplus

--- a/include/uzfs_rebuilding.h
+++ b/include/uzfs_rebuilding.h
@@ -61,6 +61,8 @@ int uzfs_zvol_release_internal_clone(zvol_state_t *zv,
  */
 int uzfs_destroy_all_internal_snapshots(zvol_state_t *zv);
 boolean_t is_stale_clone(zvol_state_t *);
+int uzfs_destroy_all_iosnap_snapshots(zvol_state_t *zv);
+boolean_t is_stale_clone(zvol_state_t *);
 
 #ifdef __cplusplus
 }

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -1512,6 +1512,7 @@ uzfs_zvol_rebuild_scanner(void *arg)
 	uint64_t	payload_size = 0;
 	char		*snap_name;
 	zvol_rebuild_scanner_info_t	*warg = NULL;
+	char		*at_ptr = NULL;
 
 	if ((rc = setsockopt(fd, SOL_SOCKET, SO_LINGER, &lo, sizeof (lo)))
 	    != 0) {
@@ -1698,6 +1699,11 @@ read_socket:
 					    snap_zv->zv_name);
 					LOG_INFO("closing snap %s", snap_name);
 					uzfs_close_dataset(snap_zv);
+					at_ptr = strchr(snap_name, '@');
+					VERIFY3P(at_ptr, !=, NULL);
+					VERIFY0(strncmp(at_ptr + 1,
+					    IO_DIFF_SNAPNAME,
+					    sizeof (IO_DIFF_SNAPNAME) - 1));
 #if DEBUG
 					if (inject_error.delay.
 					    helping_replica_rebuild_complete
@@ -1733,6 +1739,10 @@ exit:
 			snap_name = kmem_asprintf("%s", snap_zv->zv_name);
 			LOG_INFO("closing snap on conn break %s", snap_name);
 			uzfs_close_dataset(snap_zv);
+			at_ptr = strchr(snap_name, '@');
+			VERIFY3P(at_ptr, !=, NULL);
+			VERIFY0(strncmp(at_ptr + 1, IO_DIFF_SNAPNAME,
+			    sizeof (IO_DIFF_SNAPNAME) - 1));
 #if DEBUG
 			if (inject_error.delay.helping_replica_rebuild_complete
 			    == 1)
@@ -2189,6 +2199,9 @@ open_zvol(int fd, zvol_info_t **zinfopp)
 		goto error_ret;
 	}
 
+	/* Destroy snaps that are internally created to help during rebuild */
+	uzfs_destroy_all_iosnap_snapshots(zinfo->main_zv);
+
 	status = find_apt_zvol_status(zinfo, &open_data);
 	if (status == ZVOL_STATUS_HEALTHY) {
 		ASSERT3P(zinfo->snapshot_zv, ==, NULL);
@@ -2214,6 +2227,12 @@ error_ret:
 			(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 			goto open_reply;
 		}
+
+		/*
+		 * Destroy snaps that are internally created to help
+		 * during rebuild
+		 */
+		uzfs_destroy_all_iosnap_snapshots(zinfo->clone_zv);
 	}
 	/*
 	 * TODO: Once we support multiple concurrent data connections for a


### PR DESCRIPTION
Cherry-pick for https://github.com/openebs/cstor/pull/227