### PR TITLE
adding a new op code to exchange size information while rebuilding

### DIFF
--- a/include/data_conn.h
+++ b/include/data_conn.h
@@ -72,6 +72,7 @@ void signal_fds_related_to_zinfo(zvol_info_t *zinfo);
 void quiesce_wait(zvol_info_t *zinfo);
 
 int uzfs_zvol_handle_rebuild_snap_done(zvol_io_hdr_t *, int, zvol_info_t *);
+int uzfs_zvol_handle_rebuild_snap_start(zvol_io_hdr_t *, int, zvol_info_t *);
 
 #ifdef __cplusplus
 }

--- a/include/zrepl_prot.h
+++ b/include/zrepl_prot.h
@@ -70,6 +70,7 @@ enum zvol_op_code {
 	ZVOL_OPCODE_SNAP_LIST,
 	ZVOL_OPCODE_RESIZE,
 	ZVOL_OPCODE_STATS,
+	ZVOL_OPCODE_REBUILD_SNAP_START,
 } __attribute__((packed));
 
 typedef enum zvol_op_code zvol_op_code_t;

--- a/src/uzfs_rebuilding.c
+++ b/src/uzfs_rebuilding.c
@@ -84,8 +84,15 @@ uzfs_get_io_diff(zvol_state_t *zv, blk_metadata_t *low, zvol_state_t *snap,
 	zvol_state_t *snap_zv;
 	metaobj_blk_offset_t snap_metablk;
 
-	if (!func || (lun_offset + lun_len) > zv->zv_volsize || snap == NULL)
+	if (!func || snap == NULL)
 		return (EINVAL);
+
+	// dont fail if rebuilding from lower size volume
+	if (lun_offset >= zv->zv_volsize)
+		return (0);
+	if ((lun_offset + lun_len) > zv->zv_volsize) {
+		lun_len = zv->zv_volsize - lun_offset;
+	}
 
 	get_zv_metaobj_block_details(&snap_metablk, zv, lun_offset, lun_len);
 	offset = snap_metablk.m_offset;


### PR DESCRIPTION
adding a op code which exchanges the volume size while rebuilding as we need to resize the volume before starting the snapshot rebuild if resize has happened in the past.

Signed-off-by: Pawan <pawan@mayadata.io>