### PR TITLE
feat(resize) resize the clone volume while opening the zvol

### DIFF
--- a/include/data_conn.h
+++ b/include/data_conn.h
@@ -74,6 +74,7 @@ void quiesce_wait(zvol_info_t *zinfo);
 int uzfs_zvol_handle_rebuild_snap_done(zvol_io_hdr_t *, int, zvol_info_t *);
 int uzfs_zvol_handle_rebuild_snap_start(zvol_io_hdr_t *, int, zvol_info_t *);
 
+int uzfs_zvol_resize(zvol_state_t *zv, uint64_t newsize);
 #ifdef __cplusplus
 }
 #endif

--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -89,6 +89,7 @@ struct zvol_state {
 	/* Don't use status directly. Use getter/setter of zvol_info */
 	zvol_status_t zv_status;		/* zvol status */
 	kmutex_t rebuild_mtx;
+	kmutex_t conf_mtx;
 	zvol_rebuild_info_t rebuild_info;
 	uint8_t zvol_workers;			/* zvol workers count */
 };

--- a/include/zrepl_prot.h
+++ b/include/zrepl_prot.h
@@ -99,8 +99,12 @@ struct zvol_io_hdr {
 		/* IOnum from which rebuild need to be done */
 		uint64_t	checkpointed_io_seq;
 	};
-	/* only used for read/write */
-	uint64_t	offset;
+	union {
+		/* only used for read/write */
+		uint64_t	offset;
+		/* only used for zvol open opcode */
+		uint64_t	volsize;
+	};
 	/*
 	 * Length of data in payload, with following exceptions:
 	 *  1) for read request: size of data to read (payload has zero length)

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -632,11 +632,32 @@ uzfs_zvol_handle_rebuild_snap_done(zvol_io_hdr_t *hdrp,
 }
 
 int
+uzfs_zvol_resize(zvol_state_t *zv, uint64_t newsize)
+{
+	int rc = 0;
+	uint64_t volsize = ZVOL_VOLUME_SIZE(zv);
+
+	if (volsize < newsize) {
+		LOG_INFO("resize the volume %s old size = %lu, new size = %lu",
+		    zv->zv_name, volsize, newsize);
+		rc = zvol_check_volsize(newsize, zv->zv_volblocksize);
+		if (rc == 0) {
+			rc = zvol_update_volsize(newsize, zv->zv_objset);
+			if (rc == 0)
+				zvol_size_changed(zv, newsize);
+		}
+		if (rc != 0) {
+			LOG_ERR("Failed to resize zvol %s", zv->zv_name);
+		}
+	}
+	return (rc);
+}
+
+int
 uzfs_zvol_handle_rebuild_snap_start(zvol_io_hdr_t *hdrp,
     int sfd, zvol_info_t *zinfo)
 {
 	int rc = 0;
-	uint64_t dvolsize = ZVOL_VOLUME_SIZE(zinfo->main_zv);
 	uint64_t volsize;
 
 	if (hdrp->len != sizeof (volsize)) {
@@ -648,22 +669,15 @@ uzfs_zvol_handle_rebuild_snap_start(zvol_io_hdr_t *hdrp,
 	if ((rc = uzfs_zvol_socket_read(sfd, (char *)&volsize, hdrp->len)) != 0)
 		return (rc);
 
-	if (dvolsize < volsize) {
-		LOG_INFO("resize the volume %s old size = %lu, new size = %lu",
-		    zinfo->main_zv->zv_name, dvolsize, volsize);
-		rc = zvol_check_volsize(volsize,
-		    zinfo->main_zv->zv_volblocksize);
-		if (rc == 0) {
-			rc = zvol_update_volsize(volsize,
-			    zinfo->main_zv->zv_objset);
-			if (rc == 0)
-				zvol_size_changed(zinfo->main_zv, volsize);
-		}
-		if (rc != 0) {
-			LOG_ERR("Failed to resize zvol %s",
-			    zinfo->main_zv->zv_name);
-		}
-	}
+	mutex_enter(&zinfo->main_zv->rebuild_mtx);
+	/*
+	 * In mesh rebuild, all the helping replica (including cloned volume)
+	 * will send SNAP_START op code to resize the downgraded replica. We
+	 * need to protect the resize to avoid attempting it multiple times.
+	 */
+	rc = uzfs_zvol_resize(zinfo->main_zv, volsize);
+	mutex_exit(&zinfo->main_zv->rebuild_mtx);
+
 	return (rc);
 }
 
@@ -2310,6 +2324,11 @@ open_zvol(int fd, zvol_info_t **zinfopp)
 				LOG_ERR("Failed to create clone for rebuild");
 				goto error_ret;
 			}
+		}
+		if (uzfs_zvol_resize(zinfo->clone_zv, hdr.volsize)) {
+			LOG_ERR("Failed to resize cloned volume %s",
+			    zinfo->name);
+			goto error_ret;
 		}
 		ASSERT3P(zinfo->clone_zv, !=, NULL);
 		if (zinfo->clone_zv == NULL) {

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -880,8 +880,8 @@ next_step:
 			    sfd, zinfo);
 			if (rc != 0) {
 				LOG_ERR("Rebuild snap start failed.."
-				    "for %s on fd(%d)",
-				    zinfo->name, sfd);
+				    "for %s on fd(%d) err(%d)",
+				    zinfo->name, sfd, rc);
 				goto exit;
 			}
 			continue;

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -2318,7 +2318,7 @@ open_zvol(int fd, zvol_info_t **zinfopp)
 		 * as it will be marked healthy.
 		 */
 		if (uzfs_zvol_resize(zinfo->main_zv, hdr.volsize)) {
-			LOG_ERR("Failed to resize cloned volume %s",
+			LOG_ERR("Failed to resize main volume %s",
 			    zinfo->name);
 			goto error_ret;
 		}

--- a/src/uzfs_mgmt.c
+++ b/src/uzfs_mgmt.c
@@ -351,6 +351,7 @@ uzfs_dataset_zv_create(const char *ds_name, zvol_state_t **z)
 	zv->zv_spa = spa;
 	zfs_rlock_init(&zv->zv_range_lock);
 	mutex_init(&zv->rebuild_mtx, NULL, MUTEX_DEFAULT, NULL);
+	mutex_init(&zv->conf_mtx, NULL, MUTEX_DEFAULT, NULL);
 
 	strlcpy(zv->zv_name, ds_name, MAXNAMELEN);
 
@@ -366,6 +367,7 @@ disown_free:
 		dmu_objset_disown(zv->zv_objset, zv);
 free_ret:
 		mutex_destroy(&zv->rebuild_mtx);
+		mutex_destroy(&zv->conf_mtx);
 		zfs_rlock_destroy(&zv->zv_range_lock);
 		spa_close(spa, zv);
 		kmem_free(zv, sizeof (zvol_state_t));
@@ -692,6 +694,7 @@ uzfs_close_dataset(zvol_state_t *zv)
 {
 	uzfs_rele_dataset(zv);
 	mutex_destroy(&zv->rebuild_mtx);
+	mutex_destroy(&zv->conf_mtx);
 	zfs_rlock_destroy(&zv->zv_range_lock);
 	spa_close(zv->zv_spa, zv);
 	kmem_free(zv, sizeof (zvol_state_t));


### PR DESCRIPTION
When we make a data conntection and open the zvol for reading/writing, we will check if size has been increased, if it is then we resize the clone volume so that IOs can proceed smoothly on the extented/increased volume.
 
Signed-off-by: Pawan <pawan@mayadata.io>