### PR TITLE
fix(rebuild): snap rebuild fix

### DIFF
--- a/include/mgmt_conn.h
+++ b/include/mgmt_conn.h
@@ -94,6 +94,8 @@ extern struct uzfs_mgmt_conn_list uzfs_mgmt_conns;
 
 int handle_start_rebuild_req(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 	void *payload, size_t payload_size);
+int handle_prepare_snap_req(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
+	void *payload, size_t payload_size);
 void zinfo_create_cb(zvol_info_t *zinfo, nvlist_t *create_props);
 void zinfo_destroy_cb(zvol_info_t *zinfo);
 void uzfs_zvol_mgmt_thread(void *arg);

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -113,7 +113,7 @@ typedef struct zvol_info_s {
 			int	is_io_ack_sender_created	: 1;
 			int	is_io_receiver_created		: 1;
 			int	is_snap_inprogress		: 1;
-			int	is_afs_inprogress		: 1;
+			int	disallow_snapshot		: 1;
 		};
 		int flags;
 	};

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -112,6 +112,8 @@ typedef struct zvol_info_s {
 		struct {
 			int	is_io_ack_sender_created	: 1;
 			int	is_io_receiver_created		: 1;
+			int	is_snap_inprogress		: 1;
+			int	is_afs_inprogress		: 1;
 		};
 		int flags;
 	};

--- a/include/zrepl_prot.h
+++ b/include/zrepl_prot.h
@@ -71,6 +71,8 @@ enum zvol_op_code {
 	ZVOL_OPCODE_RESIZE,
 	ZVOL_OPCODE_STATS,
 	ZVOL_OPCODE_REBUILD_SNAP_START,
+	ZVOL_OPCODE_SNAP_PREPARE,
+	ZVOL_OPCODE_AFS_DONE,
 } __attribute__((packed));
 
 typedef enum zvol_op_code zvol_op_code_t;

--- a/include/zrepl_prot.h
+++ b/include/zrepl_prot.h
@@ -72,7 +72,7 @@ enum zvol_op_code {
 	ZVOL_OPCODE_STATS,
 	ZVOL_OPCODE_REBUILD_SNAP_START,
 	ZVOL_OPCODE_SNAP_PREPARE,
-	ZVOL_OPCODE_AFS_DONE,
+	ZVOL_OPCODE_AFS_STARTED,
 } __attribute__((packed));
 
 typedef enum zvol_op_code zvol_op_code_t;

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -1748,15 +1748,17 @@ retry:
 					rc = uzfs_zvol_read_header(fd, &hdr);
 					do {
 						if (rc != 0) {
-							LOG_ERR("afs started read"
-							    " failed zvol %s err(%d)",
+							LOG_ERR("afs started "
+							    "read failed "
+							    "zvol %s err(%d)",
 							    zinfo->name, rc);
 							break;
 						}
 						if (hdr.opcode !=
 						    ZVOL_OPCODE_AFS_STARTED) {
-							LOG_ERR("afs started not"
-							    "received zvol %s",
+							LOG_ERR("afs started "
+							    "not received "
+							    "zvol = %s",
 							    zinfo->name);
 							rc = -1;
 							break;

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -1740,9 +1740,10 @@ retry:
 					/*
 					 * wait for the downgraded replica to
 					 * transition into the AFS mode. After
-					 * that we can reset the afs_inprogress
-					 * as downgraded replica can now handle
-					 * the snapshot command gracefully.
+					 * that we can reset the disallow
+					 * snapshot flag as downgraded replica
+					 * can now handle the snapshot command
+					 * gracefully.
 					 */
 					rc = uzfs_zvol_read_header(fd, &hdr);
 					if (rc != 0) {

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -1685,6 +1685,17 @@ read_socket:
 #endif
 			io_seq = hdr.checkpointed_io_seq;
 retry:
+			if ((zinfo->state == ZVOL_INFO_STATE_OFFLINE) ||
+			    (!zinfo->is_io_ack_sender_created)) {
+				LOG_ERR("scanner [%s:%d] in err state",
+				    zinfo->name, warg->fd);
+				goto exit;
+			}
+			if (warg->is_fd_errored) {
+				LOG_ERR("scanner [%s:%d] errored at ack_sender",
+				    zinfo->name, warg->fd);
+				goto exit;
+			}
 
 			if (snap_zv == NULL) {
 				rc = uzfs_get_snap_zv_ionum(zinfo,

--- a/src/mgmt_conn.c
+++ b/src/mgmt_conn.c
@@ -995,6 +995,13 @@ uzfs_zvol_execute_async_command(void *arg)
 	switch (async_task->hdr.opcode) {
 	case ZVOL_OPCODE_SNAP_CREATE:
 		snap = async_task->payload;
+		if (zinfo->is_snap_inprogress == 0) {
+			LOG_ERR("Failed to create snapshot %s"
+			    " because snap inprogress is not set", snap);
+			async_task->status = ZVOL_OP_STATUS_FAILED;
+			break;
+		}
+
 		rc = uzfs_zvol_create_snapshot_update_zap(zinfo, snap,
 		    async_task->hdr.io_seq);
 		if (rc != 0) {
@@ -1010,6 +1017,10 @@ uzfs_zvol_execute_async_command(void *arg)
 		} else {
 			async_task->status = ZVOL_OP_STATUS_OK;
 		}
+
+		mutex_enter(&zinfo->main_zv->rebuild_mtx);
+		zinfo->is_snap_inprogress = 0;
+		mutex_exit(&zinfo->main_zv->rebuild_mtx);
 		break;
 	case ZVOL_OPCODE_SNAP_DESTROY:
 		snap = async_task->payload;
@@ -1348,6 +1359,45 @@ end:
 	return (rc);
 }
 
+int
+handle_prepare_snap_req(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
+    void *payload, size_t payload_size)
+{
+	zvol_info_t *zinfo;
+	char zvol_name[MAX_NAME_LEN];
+
+	strlcpy(zvol_name, payload, payload_size);
+	zvol_name[payload_size] = '\0';
+
+	char *snap = strchr(zvol_name, '@');
+
+	if (!payload_size || payload_size >= MAX_NAME_LEN || !snap) {
+		LOGERRCONN(conn, "snap prep invalid payload: %s", zvol_name);
+		return (reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp));
+	}
+
+	*snap++ = '\0';
+
+	if ((zinfo = uzfs_zinfo_lookup(zvol_name)) == NULL) {
+		LOGERRCONN(conn, "snap prep Unknown zvol: %s", zvol_name);
+		return (reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp));
+	}
+
+	mutex_enter(&zinfo->main_zv->rebuild_mtx);
+	if (zinfo->is_afs_inprogress) {
+		LOGERRCONN(conn, "snap prep afs inprogress : %s", zvol_name);
+		mutex_exit(&zinfo->main_zv->rebuild_mtx);
+		return (reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp));
+	}
+	zinfo->is_snap_inprogress = 1;
+	mutex_exit(&zinfo->main_zv->rebuild_mtx);
+
+	LOGCONN(conn, "snap prepare command snap = %s progress = %d",
+	    snap, zinfo->is_snap_inprogress);
+
+	return (reply_nodata(conn, ZVOL_OP_STATUS_OK, hdrp));
+}
+
 /*
  * Process the whole message consisting of message header and optional payload.
  */
@@ -1463,16 +1513,21 @@ process_message(uzfs_mgmt_conn_t *conn)
 		}
 		if (uzfs_zvol_get_status(zinfo->main_zv) !=
 		    ZVOL_STATUS_HEALTHY) {
-			if (hdrp->opcode == ZVOL_OPCODE_SNAP_CREATE &&
-			    ZVOL_IS_REBUILDING_AFS(zinfo->main_zv)) {
-				LOG_INFO("zvol %s is not healthy and rebuild"
-				"is going on, can't take the %s snapshot,"
-				"erroring out the rebuild", zvol_name, snap);
-				mutex_enter(&zinfo->main_zv->rebuild_mtx);
-				uzfs_zvol_set_rebuild_status(zinfo->main_zv,
-				    ZVOL_REBUILDING_ERRORED);
-				mutex_exit(&zinfo->main_zv->rebuild_mtx);
+			mutex_enter(&zinfo->main_zv->rebuild_mtx);
+			if (hdrp->opcode == ZVOL_OPCODE_SNAP_CREATE) {
+				if (ZVOL_IS_REBUILDING_AFS(zinfo->main_zv)) {
+					LOG_INFO("zvol %s is not healthy and"
+					    "rebuild is going on, can't take"
+					    "the %s snapshot,"
+					    "erroring out the rebuild",
+					    zvol_name, snap);
+					uzfs_zvol_set_rebuild_status(
+					    zinfo->main_zv,
+					    ZVOL_REBUILDING_ERRORED);
+				}
+				zinfo->is_snap_inprogress = 0;
 			}
+			mutex_exit(&zinfo->main_zv->rebuild_mtx);
 			uzfs_zinfo_drop_refcnt(zinfo);
 			LOG_ERR("zvol %s is not healthy to take %s snapshot",
 			    zvol_name, snap);
@@ -1523,6 +1578,10 @@ process_message(uzfs_mgmt_conn_t *conn)
 		    payload_size);
 		break;
 
+	case ZVOL_OPCODE_SNAP_PREPARE:
+		rc = handle_prepare_snap_req(conn, hdrp, payload,
+		    payload_size);
+		break;
 	default:
 		LOGERRCONN(conn, "Message with unknown OP code %d",
 		    hdrp->opcode);

--- a/src/mgmt_conn.c
+++ b/src/mgmt_conn.c
@@ -1374,7 +1374,7 @@ handle_prepare_snap_req(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 	char zvol_name[MAX_NAME_LEN];
 
 	if (!payload_size || payload_size >= MAX_NAME_LEN) {
-		LOGERRCONN(conn, "snap prep payload to large: %s", zvol_name);
+		LOGERRCONN(conn, "snap prep payload to large");
 		return (reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp));
 	}
 
@@ -1398,7 +1398,8 @@ handle_prepare_snap_req(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 	mutex_enter(&zinfo->main_zv->rebuild_mtx);
 	while (zinfo->disallow_snapshot || zinfo->is_snap_inprogress) {
 		mutex_exit(&zinfo->main_zv->rebuild_mtx);
-		LOG_INFO("waiting for snapshot to be allowed : %s snap %s",
+		LOG_INFO("waiting ... snapshot %s : %s snap %s",
+		    zinfo->disallow_snapshot ? "disallowed" : "snap inprogress",
 		    zvol_name, snap);
 		sleep(1);
 		mutex_enter(&zinfo->main_zv->rebuild_mtx);


### PR DESCRIPTION
when we are transitioning to AFS mode and we get a snapshot
request from the user, there is a race that if snapshot
command is received after we decided to do AFS transition,
we will miss or have the inconsistant snapshot.

Here traget it self will send prepare snapshot comand to make
each replica ready to receive the snapshot command and then it will
send the snapshot command. And replicas can take the decision as
once this prepare command is successful from all the replica,
then only targe will send the snapshot command. So scanner
can take the decison correctly and can wait for the snapshot command
to finish before go into the AFS mode.

Signed-off-by: Pawan <pawan@mayadata.io>