### PR TITLE
support(travis) : TRAVIS_BRANCH in travis.yaml to determine remote branch for openebs/cstor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
     # we need cstor code
     - git clone https://github.com/openebs/cstor.git
     - cd cstor
-    - if [ ! -z ${TRAVIS_BRANCH} ]; then git checkout ${TRAVIS_BRANCH}; else git checkout develop; fi
+    - if [ ${TRAVIS_BRANCH} == "master" ]; then git checkout develop; else git checkout ${TRAVIS_BRANCH}; fi
     - git branch
     - cd ..
     # return to libcstor code

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
     # we need cstor code
     - git clone https://github.com/openebs/cstor.git
     - cd cstor
-    - [ ! -z ${TRAVIS_TAG} ] && git checkout ${TRAVIS_TAG} || git checkout develop
+    - if [ ! -z ${TRAVIS_TAG} ]; then git checkout ${TRAVIS_TAG}; else git checkout develop; fi
     - git branch
     - cd ..
     # return to libcstor code

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
     # we need cstor code
     - git clone https://github.com/openebs/cstor.git
     - cd cstor
-    - if [ ! -z ${TRAVIS_TAG} ]; then git checkout ${TRAVIS_TAG}; else git checkout develop; fi
+    - if [ ! -z ${TRAVIS_BRANCH} ]; then git checkout ${TRAVIS_BRANCH}; else git checkout develop; fi
     - git branch
     - cd ..
     # return to libcstor code

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,10 @@ install:
     - cd ..
     # we need cstor code
     - git clone https://github.com/openebs/cstor.git
+    - cd cstor
+    - [ ! -z ${TRAVIS_TAG} ] && git checkout ${TRAVIS_TAG} || git checkout develop
+    - git branch
+    - cd ..
     # return to libcstor code
     - cd libcstor
     - sh autogen.sh
@@ -59,7 +63,6 @@ install:
     - sudo ldconfig
     - cd ..
     - cd cstor
-    - git checkout v1.0.x
     - sh autogen.sh
     - ./configure --with-config=user --enable-code-coverage=yes --enable-debug --enable-uzfs=yes --with-jemalloc --with-fio=$PWD/../fio --with-libcstor=$PWD/../libcstor/include
     - make -j4;


### PR DESCRIPTION
Changes:
- Use `develop` branch of `openebs/cstor` if current branch is `master` else use branch from `${TRAVIS_BRANCH}`

Signed-off-by: mayank <mayank.patel@mayadata.io>