### PR TITLE
fix(rebuild) reset the snap_inprogress when connection is valid.

### DIFF
--- a/include/mgmt_conn.h
+++ b/include/mgmt_conn.h
@@ -94,8 +94,8 @@ extern struct uzfs_mgmt_conn_list uzfs_mgmt_conns;
 
 int handle_start_rebuild_req(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 	void *payload, size_t payload_size);
-int handle_prepare_snap_req(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
-	void *payload, size_t payload_size);
+int handle_prepare_snap_req(zvol_info_t *zinfo, uzfs_mgmt_conn_t *conn,
+    zvol_io_hdr_t *hdrp, char *zvol_name, char *snap);
 void zinfo_create_cb(zvol_info_t *zinfo, nvlist_t *create_props);
 void zinfo_destroy_cb(zvol_info_t *zinfo);
 void uzfs_zvol_mgmt_thread(void *arg);

--- a/src/mgmt_conn.c
+++ b/src/mgmt_conn.c
@@ -1380,7 +1380,6 @@ handle_prepare_snap_req(zvol_info_t *zinfo, uzfs_mgmt_conn_t *conn,
 		LOG_INFO("prep snapshot failed %s : %s snap %s",
 		    zinfo->disallow_snapshot ? "disallowed" : "snap inprogress",
 		    zvol_name, snap);
-		uzfs_zinfo_drop_refcnt(zinfo);
 		return (reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp));
 	}
 	zinfo->is_snap_inprogress = 1;

--- a/src/mgmt_conn.c
+++ b/src/mgmt_conn.c
@@ -995,12 +995,6 @@ uzfs_zvol_execute_async_command(void *arg)
 	switch (async_task->hdr.opcode) {
 	case ZVOL_OPCODE_SNAP_CREATE:
 		snap = async_task->payload;
-		if (zinfo->is_snap_inprogress == 0) {
-			LOG_ERR("Failed to create snapshot %s"
-			    " because snap inprogress is not set", snap);
-			async_task->status = ZVOL_OP_STATUS_FAILED;
-			break;
-		}
 
 		if (zinfo->disallow_snapshot) {
 			LOG_ERR("Failed to create snapshot %s"

--- a/src/mgmt_conn.c
+++ b/src/mgmt_conn.c
@@ -1025,9 +1025,13 @@ uzfs_zvol_execute_async_command(void *arg)
 			async_task->status = ZVOL_OP_STATUS_OK;
 		}
 
-		mutex_enter(&zinfo->main_zv->rebuild_mtx);
-		zinfo->is_snap_inprogress = 0;
-		mutex_exit(&zinfo->main_zv->rebuild_mtx);
+		mutex_enter(&async_tasks_mtx);
+		if (async_task->conn_closed == B_FALSE) {
+			mutex_enter(&zinfo->main_zv->rebuild_mtx);
+			zinfo->is_snap_inprogress = 0;
+			mutex_exit(&zinfo->main_zv->rebuild_mtx);
+		}
+		mutex_exit(&async_tasks_mtx);
 		break;
 	case ZVOL_OPCODE_SNAP_DESTROY:
 		snap = async_task->payload;


### PR DESCRIPTION
there may be some async task for the old connection
so we can not reset the snap_in_progress flag.
We already gurranty that we have one connection at a time so
We should check for connection to be valid before doing that.

Signed-off-by: Pawan <pawan@mayadata.io>