### PR TITLE
support(travis) : TRAVIS_BRANCH in travis.yaml to determine remote branch for openebs/cstor 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,10 @@ install:
     - cd ..
     # we need cstor code
     - git clone https://github.com/openebs/cstor.git
+    - cd cstor
+    - if [ ${TRAVIS_BRANCH} == "master" ]; then git checkout develop; else git checkout ${TRAVIS_BRANCH} || git checkout develop; fi
+    - git branch
+    - cd ..
     # return to libcstor code
     - cd libcstor
     - sh autogen.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,6 @@ install:
     - sudo ldconfig
     - cd ..
     - cd cstor
-    - git checkout develop
     - sh autogen.sh
     - ./configure --with-config=user --enable-code-coverage=yes --enable-debug --enable-uzfs=yes --with-jemalloc --with-fio=$PWD/../fio --with-libcstor=$PWD/../libcstor/include
     - make -j4;


### PR DESCRIPTION
With this change:
- Travis build will use `${TRAVIS_BRANCH}` for `openebs/cstor`. If `openebs/cstor` doesn't have `${TRAVIS_BRANCH}` then default `develop` branch will be used to build `openebs/cstor`.

Signed-off-by: mayank <mayank.patel@mayadata.io>