### PR TITLE
feat(resize): resize the volume based on status

### DIFF
--- a/src/mgmt_conn.c
+++ b/src/mgmt_conn.c
@@ -1042,16 +1042,25 @@ uzfs_zvol_execute_async_command(void *arg)
 		break;
 	case ZVOL_OPCODE_RESIZE:
 		volsize = *(uint64_t *)async_task->payload;
-		rc = zvol_check_volsize(volsize,
-		    zinfo->main_zv->zv_volblocksize);
-		if (rc == 0) {
-			rc = zvol_update_volsize(volsize,
-			    zinfo->main_zv->zv_objset);
-			if (rc == 0)
-				zvol_size_changed(zinfo->main_zv, volsize);
+		if (uzfs_zvol_get_status(zinfo->main_zv) ==
+		    ZVOL_STATUS_HEALTHY) {
+			// TODO: Is assertion with snapshot and clone
+			// data set is required here?
+			rc = uzfs_zvol_resize(zinfo->main_zv, volsize);
+		} else {
+			rc = uzfs_zvol_resize(zinfo->clone_zv, volsize);
+			if (rc != 0) {
+				LOG_ERR("Failed to resize cloned volume %s",
+				    zinfo->clone_zv->zv_name);
+				goto ret_error;
+			}
+			if (uzfs_zvol_get_rebuild_status(zinfo->main_zv) ==
+			    ZVOL_REBUILDING_AFS)
+				rc = uzfs_zvol_resize(zinfo->main_zv, volsize);
 		}
+ret_error:
 		if (rc != 0) {
-			LOG_ERR("Failed to resize zvol %s", zinfo->name);
+			LOG_ERR("Failed to resize main volume %s", zinfo->name);
 			async_task->status = ZVOL_OP_STATUS_FAILED;
 		} else {
 			async_task->status = ZVOL_OP_STATUS_OK;

--- a/src/mgmt_conn.c
+++ b/src/mgmt_conn.c
@@ -1062,7 +1062,7 @@ uzfs_zvol_execute_async_command(void *arg)
 				goto ret_error;
 			}
 			if (uzfs_zvol_get_rebuild_status(zinfo->main_zv) ==
-			    ZVOL_REBUILDING_AFS)
+			    ZVOL_REBUILDING_AFS) {
 				rc = uzfs_zvol_resize(zinfo->main_zv, volsize);
 				if (rc != 0) {
 					mutex_exit(
@@ -1072,8 +1072,11 @@ uzfs_zvol_execute_async_command(void *arg)
 					    zinfo->main_zv->zv_name);
 					goto ret_error;
 				}
+			}
 		}
 		mutex_exit(&zinfo->main_zv->rebuild_mtx);
+		LOG_INFO("Successfully resized the zvol "
+		    "to %lu bytes", volsize);
 ret_error:
 		if (rc != 0) {
 			async_task->status = ZVOL_OP_STATUS_FAILED;

--- a/src/mgmt_conn.c
+++ b/src/mgmt_conn.c
@@ -1043,6 +1043,8 @@ uzfs_zvol_execute_async_command(void *arg)
 	case ZVOL_OPCODE_RESIZE:
 		volsize = *(uint64_t *)async_task->payload;
 		// Take rebuild_mtx lock since we are checking the status
+		LOG_INFO("Resizing zvol %s to %lu bytes",
+		    zinfo->name, volsize);
 		mutex_enter(&zinfo->main_zv->rebuild_mtx);
 		if (uzfs_zvol_get_status(zinfo->main_zv) ==
 		    ZVOL_STATUS_HEALTHY) {
@@ -1075,8 +1077,8 @@ uzfs_zvol_execute_async_command(void *arg)
 			}
 		}
 		mutex_exit(&zinfo->main_zv->rebuild_mtx);
-		LOG_INFO("Successfully resized the zvol "
-		    "to %lu bytes", volsize);
+		LOG_INFO("Successfully resized zvol %s "
+		    "to %lu bytes", zinfo->name, volsize);
 ret_error:
 		if (rc != 0) {
 			async_task->status = ZVOL_OP_STATUS_FAILED;


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

This PR resizes the volume based on status of zvol.
When target sends resize command
1. If replica is in healthy status then main volume will 
    resizes to updated size
2. If replica is in degraded state then clone volume will
    resizes to updated size
3. If replica is in AFS mode then clone and volume will 
    resizes to updated size
Manual testing is done

TODO:
1. Unit test will be covered on different PR after #https://github.com/openebs/cstor/pull/267 checked in.