### PR TITLE
chore(logs): logging  based on log level type

### DIFF
--- a/src/zrepl_mgmt.c
+++ b/src/zrepl_mgmt.c
@@ -78,7 +78,11 @@ zrepl_log(enum zrepl_log_level lvl, const char *fmt, ...)
 	va_start(args, fmt);
 	vsnprintf(line + off, sizeof (line) - off, fmt, args);
 	va_end(args);
-	fprintf(stderr, "%s\n", line);
+	if (lvl == LOG_LEVEL_ERR) {
+		fprintf(stderr, "%s\n", line);
+	} else {
+		fprintf(stdout, "%s\n", line);
+	}
 }
 
 int


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
This PR fixes the logging based on the type of log level.
If log level is `LOG_LEVEL_ERR`  then code will redirect to stderr else redirect to stdout.