### PR TITLE
fix(sock): change sock file directory

### DIFF
--- a/include/libuzfs.h
+++ b/include/libuzfs.h
@@ -28,7 +28,7 @@ extern int kthread_nr;
 
 #define	PEND_CONNECTIONS 10
 
-#define	UZFS_SOCK "/tmp/uzfs.sock"
+#define	UZFS_SOCK "/var/run/uzfs.sock"
 #define	LOCK_FILE "/tmp/zrepl.lock"
 
 #define	SET_ERR(err) (errno = err, -1)


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
This PR changes the sock file directory from /tmp to /var/run to decouple dependency of when the pool is running in a pod.