### PR TITLE
feat(readonly): Adding readonly support for uzfs zvol

### DIFF
--- a/include/gtest_utils.h
+++ b/include/gtest_utils.h
@@ -110,6 +110,7 @@ public:
 
 	void create();
 	void import();
+	void pExport();
 	void createZvol(std::string name, std::string arg = "");
 	void destroyZvol(std::string name);
 	std::string getZvolName(std::string name);

--- a/include/mgmt_conn.h
+++ b/include/mgmt_conn.h
@@ -62,6 +62,7 @@ typedef struct uzfs_mgmt_conn {
 	int		conn_procn;	// bytes already read/written
 	zvol_io_hdr_t	*conn_hdr;	// header of currently processed cmd
 	time_t		conn_last_connect;  // time of last attempted connect()
+	boolean_t disabled;	// connection is disabled due to internal errors
 } uzfs_mgmt_conn_t;
 
 /*
@@ -107,6 +108,9 @@ int uzfs_get_snap_zv_ionum(zvol_info_t *, uint64_t, zvol_state_t **);
 
 int uzfs_zvol_get_snap_dataset_with_io(zvol_info_t *zinfo,
     char *snapname, uint64_t *snapshot_io_num, zvol_state_t **snap_zv);
+
+int disable_zinfo_conn(char *zv_name);
+int enable_zinfo_conn(char *zv_name);
 
 #ifdef __cplusplus
 }

--- a/include/mgmt_conn.h
+++ b/include/mgmt_conn.h
@@ -62,7 +62,11 @@ typedef struct uzfs_mgmt_conn {
 	int		conn_procn;	// bytes already read/written
 	zvol_io_hdr_t	*conn_hdr;	// header of currently processed cmd
 	time_t		conn_last_connect;  // time of last attempted connect()
-	boolean_t disabled;	// connection is disabled due to internal errors
+
+	/*
+	 * connection is disabled since zvol is readonly mode
+	 */
+	boolean_t disabled;
 } uzfs_mgmt_conn_t;
 
 /*
@@ -109,8 +113,8 @@ int uzfs_get_snap_zv_ionum(zvol_info_t *, uint64_t, zvol_state_t **);
 int uzfs_zvol_get_snap_dataset_with_io(zvol_info_t *zinfo,
     char *snapname, uint64_t *snapshot_io_num, zvol_state_t **snap_zv);
 
-int disable_zinfo_conn(char *zv_name);
-int enable_zinfo_conn(char *zv_name);
+void disable_zinfo_mgmt_conn(zvol_info_t *zinfo);
+void enable_zinfo_mgmt_conn(zvol_info_t *zinfo);
 
 #ifdef __cplusplus
 }

--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -92,9 +92,17 @@ struct zvol_state {
 	kmutex_t conf_mtx;
 	zvol_rebuild_info_t rebuild_info;
 	uint8_t zvol_workers;			/* zvol workers count */
+
+	uint32_t zv_flags;			/* zvol flags */
 };
 
+/* zv flag definition */
+#define	ZVOL_RDONLY	0x1
+
 #define	ZVOL_VOLUME_SIZE(zv)	(zv->zv_volsize)
+
+#define	IS_ZVOL_OFFLINE(zv)		((zv->zv_flags & ZVOL_RDONLY))
+
 typedef struct zvol_state zvol_state_t;
 
 #define	UZFS_IO_TX_ASSIGN_FAIL	1

--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -101,7 +101,7 @@ struct zvol_state {
 
 #define	ZVOL_VOLUME_SIZE(zv)	(zv->zv_volsize)
 
-#define	IS_ZVOL_OFFLINE(zv)		((zv->zv_flags & ZVOL_RDONLY))
+#define	IS_ZVOL_READONLY(zv)		((zv->zv_flags & ZVOL_RDONLY))
 
 typedef struct zvol_state zvol_state_t;
 

--- a/include/uzfs_mgmt.h
+++ b/include/uzfs_mgmt.h
@@ -46,6 +46,7 @@ int get_snapshot_zv(zvol_state_t *zv, const char *snap_name,
 extern int destroy_snapshot_zv(zvol_state_t *zv, char *snap_name);
 
 int uzfs_pool_create(const char *name, char *path, spa_t **spa);
+int update_zvol_property(zvol_state_t *, nvlist_t *);
 #ifdef __cplusplus
 }
 #endif

--- a/include/uzfs_prop.h
+++ b/include/uzfs_prop.h
@@ -1,0 +1,16 @@
+#ifndef	_UZFS_PROP_H
+#define	_UZFS_PROP_H
+#include <sys/nvpair.h>
+
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+int uzfs_zfs_set_prop(const char *name, zprop_source_t source, nvlist_t *list);
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif

--- a/include/uzfs_prop.h
+++ b/include/uzfs_prop.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-int uzfs_zfs_set_prop(const char *name, zprop_source_t source, nvlist_t *list);
+int uzfs_zinfo_update_rdonly(const char *name, const char *val);
 
 #ifdef	__cplusplus
 }

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,7 +25,8 @@ EXTRA_DIST = \
 			 uzfs_zap.c \
 			 vdev_disk_aio.c \
 			 zrepl_mgmt.c	\
-			 uzfs_test_mgmt.c
+			 uzfs_test_mgmt.c \
+			 uzfs_prop.c
 
 nodist_libcstor_la_SOURCES = $(EXTRA_DIST)
 

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -242,6 +242,9 @@ uzfs_submit_writes(zvol_info_t *zinfo, zvol_io_cmd_t *zio_cmd)
 	}
 #endif
 
+	if (IS_ZVOL_OFFLINE(zinfo->main_zv))
+		return (-1);
+
 	while (remain > 0) {
 		if (remain < sizeof (*write_hdr))
 			return (-1);
@@ -267,6 +270,9 @@ uzfs_submit_writes(zvol_info_t *zinfo, zvol_io_cmd_t *zio_cmd)
 
 		/* IO to clone should be sent only when it is from app */
 		if (!is_rebuild && !ZVOL_IS_HEALTHY(zinfo->main_zv)) {
+			if (IS_ZVOL_OFFLINE(zinfo->clone_zv))
+				return (-1);
+
 			rc = uzfs_write_data(zinfo->clone_zv, datap,
 			    data_offset, write_hdr->len, &metadata,
 			    is_rebuild);

--- a/src/data_conn.c
+++ b/src/data_conn.c
@@ -242,7 +242,7 @@ uzfs_submit_writes(zvol_info_t *zinfo, zvol_io_cmd_t *zio_cmd)
 	}
 #endif
 
-	if (IS_ZVOL_OFFLINE(zinfo->main_zv))
+	if (IS_ZVOL_READONLY(zinfo->main_zv))
 		return (-1);
 
 	while (remain > 0) {
@@ -270,9 +270,6 @@ uzfs_submit_writes(zvol_info_t *zinfo, zvol_io_cmd_t *zio_cmd)
 
 		/* IO to clone should be sent only when it is from app */
 		if (!is_rebuild && !ZVOL_IS_HEALTHY(zinfo->main_zv)) {
-			if (IS_ZVOL_OFFLINE(zinfo->clone_zv))
-				return (-1);
-
 			rc = uzfs_write_data(zinfo->clone_zv, datap,
 			    data_offset, write_hdr->len, &metadata,
 			    is_rebuild);

--- a/src/mgmt_conn.c
+++ b/src/mgmt_conn.c
@@ -1021,8 +1021,11 @@ uzfs_zvol_execute_async_command(void *arg)
 		if (zinfo->disallow_snapshot ||
 		    IS_ZVOL_READONLY(zinfo->main_zv)) {
 			LOG_ERR("Failed to create snapshot %s"
-			    " because snapshot is not allowed or"
-			    " volume is readonly", snap);
+			    " because %s",
+			    snap, (zinfo->disallow_snapshot ?
+			    "snapshot is not allowed" :
+			    (IS_ZVOL_READONLY(zinfo->main_zv) ?
+			    "Volume is readonly" : "Internal error")));
 			async_task->status = ZVOL_OP_STATUS_FAILED;
 			break;
 		}

--- a/src/uzfs_prop.c
+++ b/src/uzfs_prop.c
@@ -1,0 +1,41 @@
+#include <zrepl_mgmt.h>
+#include <uzfs_mgmt.h>
+
+/*
+ * This file defines function to set property of uzfs zvol
+ */
+int
+uzfs_zfs_set_prop(const char *name, zprop_source_t source, nvlist_t *list)
+{
+	zvol_info_t *zinfo;
+	int error;
+
+	/* fetch zinfo for given volume */
+	zinfo = uzfs_zinfo_lookup(name);
+	if (zinfo == NULL) {
+		LOG_ERR("Invalid volume %s", name);
+		return (EINVAL);
+	}
+
+	(void) pthread_mutex_lock(&zinfo->zinfo_mutex);
+	error = update_zvol_property(zinfo->main_zv, list);
+	if (error) {
+		LOG_ERR("Property updation failed(%d)", error);
+		goto end;
+	}
+
+	if (error == 0 && zinfo->clone_zv != NULL) {
+		error = update_zvol_property(zinfo->clone_zv, list);
+		if (error) {
+			LOG_ERR("Updation property failed(%d)", error);
+			goto end;
+		}
+
+	}
+
+end:
+	(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
+	/* dropping refcount for uzfs_zinfo_lookup */
+	uzfs_zinfo_drop_refcnt(zinfo);
+	return (error);
+}


### PR DESCRIPTION
changes:
- Adding support to make uzfs zvol readonly
To set zvol readonly:
```
zfs  set io.openebs:readonly=on testp/testv
```

To unset zvol readonly:
```
zfs  set io.openebs:readonly=off testp/vol1
```
scenario:
- If zvol is set readonly then zrepl won't scan this zvol to make connection with target
- if zvol was already connected while setting readonly mode then write/snapshot{prepare/create} will fail

Signed-off-by: mayank <mayank.patel@mayadata.io>