### PR TITLE
 feat(readonly): Adding readonly support for uzfs pool 

### DIFF
--- a/include/gtest_utils.h
+++ b/include/gtest_utils.h
@@ -111,6 +111,7 @@ public:
 	void create();
 	void import();
 	void pExport();
+	bool isReadOnly();
 	void createZvol(std::string name, std::string arg = "");
 	void destroyZvol(std::string name);
 	std::string getZvolName(std::string name);

--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -101,7 +101,8 @@ struct zvol_state {
 
 #define	ZVOL_VOLUME_SIZE(zv)	(zv->zv_volsize)
 
-#define	IS_ZVOL_READONLY(zv)		((zv->zv_flags & ZVOL_RDONLY))
+#define	IS_ZVOL_READONLY(zv)	\
+	((zv->zv_flags & ZVOL_RDONLY) || (zv->zv_spa->readonly))
 
 typedef struct zvol_state zvol_state_t;
 

--- a/include/uzfs_mgmt.h
+++ b/include/uzfs_mgmt.h
@@ -47,6 +47,7 @@ extern int destroy_snapshot_zv(zvol_state_t *zv, char *snap_name);
 
 int uzfs_pool_create(const char *name, char *path, spa_t **spa);
 int update_zvol_property(zvol_state_t *, nvlist_t *);
+int is_internally_created_clone_volume(const char *ds_name);
 #ifdef __cplusplus
 }
 #endif

--- a/include/uzfs_prop.h
+++ b/include/uzfs_prop.h
@@ -9,6 +9,7 @@ extern "C" {
 
 int uzfs_zinfo_update_rdonly(const char *name, const char *val);
 
+int uzfs_zpool_rdonly_cb(const char *name, void *arg);
 #ifdef	__cplusplus
 }
 #endif

--- a/src/uzfs_prop.c
+++ b/src/uzfs_prop.c
@@ -41,3 +41,38 @@ end:
 	nvlist_free(props);
 	return (error);
 }
+
+int
+uzfs_zpool_rdonly_cb(const char *ds_name, void *arg)
+{
+	char *val = arg;
+	zvol_info_t *zinfo;
+
+	if (strrchr(ds_name, '@') != NULL) {
+		return (0);
+	}
+
+	if (strchr(ds_name, '/') == NULL) {
+		return (0);
+	}
+
+	if (is_internally_created_clone_volume(ds_name) == 0) {
+		return (0);
+	}
+
+	/* fetch zinfo for given volume */
+	zinfo = uzfs_zinfo_lookup(ds_name);
+	if (zinfo == NULL) {
+		LOG_ERR("Invalid volume %s", ds_name);
+		return (EINVAL);
+	}
+
+	if (IS_ZVOL_READONLY(zinfo->main_zv)) {
+		disable_zinfo_mgmt_conn(zinfo);
+	} else {
+		enable_zinfo_mgmt_conn(zinfo);
+	}
+
+	uzfs_zinfo_drop_refcnt(zinfo);
+	return (0);
+}


### PR DESCRIPTION
changes:
- Adding support to make uzfs pool readonly
To set pool readonly:
```
zpool set io.openebs:readonly=on testp
```

To unset pool readonly:
```
zpool  set io.openebs:readonly=off testp
```
scenario:
- If pool is set readonly then zrepl won't scan any zvol, created on this pool, to make connection with target
- if zvol was already connected on the pool while setting readonly mode then write/snapshot{prepare/create} for the zvol will fail

Fixes : https://github.com/openebs/openebs/issues/2937
Signed-off-by: mayank <mayank.patel@mayadata.io>