### PR TITLE
fix(sock file): update sock file directory from /var/run to /var/tmp/sock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ before_install:
     - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
     - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++
 install:
+    # zrepl will make use of /var/tmp/sock directory to create a sock file.
+    - mkdir -p /var/tmp/sock
     - pushd .
     - cd /usr/src/gtest
     - sudo cmake CMakeLists.txt

--- a/include/libuzfs.h
+++ b/include/libuzfs.h
@@ -28,7 +28,7 @@ extern int kthread_nr;
 
 #define	PEND_CONNECTIONS 10
 
-#define	UZFS_SOCK "/var/run/uzfs.sock"
+#define	UZFS_SOCK "/var/tmp/sock/uzfs.sock"
 #define	LOCK_FILE "/tmp/zrepl.lock"
 
 #define	SET_ERR(err) (errno = err, -1)


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
This PR updates the sock file path from `/var/run` to `/var/tmp/sock`.
**Note:** If developers want to run zrepl first step is to create `/var/tmp/sock` directory.
Maya PR: #https://github.com/openebs/maya/pull/1605 