### PR TITLE
feat(list_snap): LIST_SNAP uzfs ioctl implementation

### DIFF
--- a/include/libuzfs.h
+++ b/include/libuzfs.h
@@ -91,6 +91,7 @@ typedef struct uzfs_monitor {
     _UZFS_IOC(ZFS_IOC_CLONE, 1, 1, "clone the volume")                         \
     _UZFS_IOC(ZFS_IOC_ERROR_LOG, 0, 0, "get the error log")                    \
     _UZFS_IOC(ZFS_IOC_STATS, 0, 0, "get the zfs volume stats")                 \
+    _UZFS_IOC(ZFS_IOC_LIST_SNAP, 0, 0, "get the volume snapshots list")        \
     _UZFS_IOC(ZFS_IOC_CLEAR, 1, 0, "clear the zpool error counters")
 
 
@@ -108,6 +109,7 @@ extern int uzfs_recv_response(int fd, zfs_cmd_t *zc);
 extern int uzfs_client_init(const char *sock_path);
 extern int is_main_thread(void);
 int uzfs_ioc_stats(zfs_cmd_t *zc, nvlist_t *nvl);
+int uzfs_ioc_list_snap(zfs_cmd_t *zc, nvlist_t *nvl);
 
 extern int do_sendfd(int sock, int fd);
 extern int do_recvfd(int sock);

--- a/include/mgmt_conn.h
+++ b/include/mgmt_conn.h
@@ -113,8 +113,6 @@ int uzfs_get_snap_zv_ionum(zvol_info_t *, uint64_t, zvol_state_t **);
 int uzfs_zvol_get_snap_dataset_with_io(zvol_info_t *zinfo,
     char *snapname, uint64_t *snapshot_io_num, zvol_state_t **snap_zv);
 
-extern struct json_object *uzfs_zvol_fetch_json_snapshot_list(zvol_info_t *,
-    char *, boolean_t, int *);
 extern int uzfs_zvol_add_nvl_snapshot_list(zvol_info_t *, nvlist_t *);
 void disable_zinfo_mgmt_conn(zvol_info_t *zinfo);
 void enable_zinfo_mgmt_conn(zvol_info_t *zinfo);

--- a/include/mgmt_conn.h
+++ b/include/mgmt_conn.h
@@ -113,6 +113,9 @@ int uzfs_get_snap_zv_ionum(zvol_info_t *, uint64_t, zvol_state_t **);
 int uzfs_zvol_get_snap_dataset_with_io(zvol_info_t *zinfo,
     char *snapname, uint64_t *snapshot_io_num, zvol_state_t **snap_zv);
 
+extern struct json_object *uzfs_zvol_fetch_json_snapshot_list(zvol_info_t *,
+    boolean_t, int *);
+extern int uzfs_zvol_add_nvl_snapshot_list(zvol_info_t *, nvlist_t *);
 void disable_zinfo_mgmt_conn(zvol_info_t *zinfo);
 void enable_zinfo_mgmt_conn(zvol_info_t *zinfo);
 

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -205,8 +205,8 @@ typedef struct zvol_info_s {
 	zfs_histogram_t uzfs_wio_histogram[ZFS_HISTOGRAM_IO_SIZE /
 	    ZFS_HISTOGRAM_IO_BLOCK + 1];
 
-	struct json_object *snap_map;
-	pthread_mutex_t	snap_map_mutex;
+	struct json_object	*snap_map;
+	kmutex_t	snap_map_mutex;
 } zvol_info_t;
 
 typedef struct zvol_rebuild_scanner_info_s {

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -204,6 +204,9 @@ typedef struct zvol_info_s {
 	    ZFS_HISTOGRAM_IO_BLOCK + 1];
 	zfs_histogram_t uzfs_wio_histogram[ZFS_HISTOGRAM_IO_SIZE /
 	    ZFS_HISTOGRAM_IO_BLOCK + 1];
+
+	struct json_object *snap_list;
+	pthread_mutex_t	snap_list_mutex;
 } zvol_info_t;
 
 typedef struct zvol_rebuild_scanner_info_s {

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -205,8 +205,8 @@ typedef struct zvol_info_s {
 	zfs_histogram_t uzfs_wio_histogram[ZFS_HISTOGRAM_IO_SIZE /
 	    ZFS_HISTOGRAM_IO_BLOCK + 1];
 
-	struct json_object *snap_list;
-	pthread_mutex_t	snap_list_mutex;
+	struct json_object *snap_map;
+	pthread_mutex_t	snap_map_mutex;
 } zvol_info_t;
 
 typedef struct zvol_rebuild_scanner_info_s {

--- a/src/mgmt_conn.c
+++ b/src/mgmt_conn.c
@@ -861,6 +861,7 @@ uzfs_zvol_add_nvl_snapshot_list(zvol_info_t *zinfo, nvlist_t *nvl)
 
 	if (error != 0) {
 		pthread_mutex_unlock(&zinfo->snap_map_mutex);
+		LOG_ERR("err %d for %s listsnap", error, zinfo->name);
 		return (error);
 	}
 

--- a/src/mgmt_conn.c
+++ b/src/mgmt_conn.c
@@ -793,7 +793,7 @@ uzfs_zvol_get_snap_jmap_ref(zvol_info_t *zinfo, struct json_object **jmapp)
 	int error = 0;
 
 	ASSERT(MUTEX_HELD(&zinfo->snap_map_mutex));
-	*jampp = NULL;
+	*jmapp = NULL;
 	if (zinfo->snap_map == NULL) {
 
 		jmap = uzfs_zvol_fetch_snapshot_jmap(zinfo, &error);
@@ -822,7 +822,7 @@ uzfs_zvol_update_snapshot_jmap(zvol_info_t *zinfo, char *snapname,
 	int ret = 0;
 	struct json_object *jmap;
 
-	pthread_mutex_lock(&zinfo->snap_map_mutex);
+	mutex_enter(&zinfo->snap_map_mutex);
 	ret = uzfs_zvol_get_snap_jmap_ref(zinfo, &jmap);
 	if (ret == 0) {
 		if (add)
@@ -835,7 +835,7 @@ uzfs_zvol_update_snapshot_jmap(zvol_info_t *zinfo, char *snapname,
 			json_object_put(zinfo->snap_map);
 		zinfo->snap_map = NULL;
 	}
-	pthread_mutex_unlock(&zinfo->snap_map_mutex);
+	mutex_exit(&zinfo->snap_map_mutex);
 	return (0);
 }
 
@@ -855,11 +855,11 @@ uzfs_zvol_add_nvl_snapshot_list(zvol_info_t *zinfo, nvlist_t *nvl)
 	int error = 0;
 	const char *json_string;
 
-	pthread_mutex_lock(&zinfo->snap_map_mutex);
+	mutex_enter(&zinfo->snap_map_mutex);
 	error = uzfs_zvol_get_snap_jmap_ref(zinfo, &jmap);
 
 	if (error != 0) {
-		pthread_mutex_unlock(&zinfo->snap_map_mutex);
+		mutex_exit(&zinfo->snap_map_mutex);
 		LOG_ERR("err %d for %s listsnap", error, zinfo->name);
 		return (error);
 	}
@@ -875,7 +875,7 @@ uzfs_zvol_add_nvl_snapshot_list(zvol_info_t *zinfo, nvlist_t *nvl)
 
 	/* This will decrement refcount of jmap as well */
 	json_object_put(jobj);
-	pthread_mutex_unlock(&zinfo->snap_map_mutex);
+	mutex_exit(&zinfo->snap_map_mutex);
 
 	return (0);
 }

--- a/src/zrepl_mgmt.c
+++ b/src/zrepl_mgmt.c
@@ -323,7 +323,7 @@ uzfs_zinfo_init_mutex(zvol_info_t *zinfo)
 	(void) pthread_mutex_init(&zinfo->zinfo_mutex, NULL);
 	(void) pthread_cond_init(&zinfo->io_ack_cond, NULL);
 	(void) pthread_mutex_init(&zinfo->zinfo_ionum_mutex, NULL);
-	(void) pthread_mutex_init(&zinfo->snap_map_mutex, NULL);
+	mutex_init(&zinfo->snap_map_mutex, NULL, MUTEX_DEFAULT, NULL);
 }
 
 static void
@@ -333,7 +333,7 @@ uzfs_zinfo_destroy_mutex(zvol_info_t *zinfo)
 	(void) pthread_mutex_destroy(&zinfo->zinfo_mutex);
 	(void) pthread_cond_destroy(&zinfo->io_ack_cond);
 	(void) pthread_mutex_destroy(&zinfo->zinfo_ionum_mutex);
-	(void) pthread_mutex_destroy(&zinfo->snap_map_mutex);
+	mutex_destroy(&zinfo->snap_map_mutex);
 }
 
 int

--- a/src/zrepl_mgmt.c
+++ b/src/zrepl_mgmt.c
@@ -323,7 +323,7 @@ uzfs_zinfo_init_mutex(zvol_info_t *zinfo)
 	(void) pthread_mutex_init(&zinfo->zinfo_mutex, NULL);
 	(void) pthread_cond_init(&zinfo->io_ack_cond, NULL);
 	(void) pthread_mutex_init(&zinfo->zinfo_ionum_mutex, NULL);
-	(void) pthread_mutex_init(&zinfo->snap_list_mutex, NULL);
+	(void) pthread_mutex_init(&zinfo->snap_map_mutex, NULL);
 }
 
 static void
@@ -333,7 +333,7 @@ uzfs_zinfo_destroy_mutex(zvol_info_t *zinfo)
 	(void) pthread_mutex_destroy(&zinfo->zinfo_mutex);
 	(void) pthread_cond_destroy(&zinfo->io_ack_cond);
 	(void) pthread_mutex_destroy(&zinfo->zinfo_ionum_mutex);
-	(void) pthread_mutex_destroy(&zinfo->snap_list_mutex);
+	(void) pthread_mutex_destroy(&zinfo->snap_map_mutex);
 }
 
 int
@@ -444,8 +444,8 @@ uzfs_zinfo_free(zvol_info_t *zinfo)
 	(void) uzfs_zinfo_destroy_mutex(zinfo);
 	ASSERT(STAILQ_EMPTY(&zinfo->complete_queue));
 
-	if (zinfo->snap_list)
-		json_object_put(zinfo->snap_list);
+	if (zinfo->snap_map)
+		json_object_put(zinfo->snap_map);
 
 	free(zinfo);
 	return (0);

--- a/src/zrepl_mgmt.c
+++ b/src/zrepl_mgmt.c
@@ -31,6 +31,7 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <uzfs_rebuilding.h>
+#include <json-c/json_object.h>
 
 #define	ZVOL_THREAD_STACKSIZE (2 * 1024 * 1024)
 
@@ -322,6 +323,7 @@ uzfs_zinfo_init_mutex(zvol_info_t *zinfo)
 	(void) pthread_mutex_init(&zinfo->zinfo_mutex, NULL);
 	(void) pthread_cond_init(&zinfo->io_ack_cond, NULL);
 	(void) pthread_mutex_init(&zinfo->zinfo_ionum_mutex, NULL);
+	(void) pthread_mutex_init(&zinfo->snap_list_mutex, NULL);
 }
 
 static void
@@ -331,6 +333,7 @@ uzfs_zinfo_destroy_mutex(zvol_info_t *zinfo)
 	(void) pthread_mutex_destroy(&zinfo->zinfo_mutex);
 	(void) pthread_cond_destroy(&zinfo->io_ack_cond);
 	(void) pthread_mutex_destroy(&zinfo->zinfo_ionum_mutex);
+	(void) pthread_mutex_destroy(&zinfo->snap_list_mutex);
 }
 
 int
@@ -440,6 +443,9 @@ uzfs_zinfo_free(zvol_info_t *zinfo)
 	taskq_destroy(zinfo->uzfs_zvol_taskq);
 	(void) uzfs_zinfo_destroy_mutex(zinfo);
 	ASSERT(STAILQ_EMPTY(&zinfo->complete_queue));
+
+	if (zinfo->snap_list)
+		json_object_put(zinfo->snap_list);
 
 	free(zinfo);
 	return (0);


### PR DESCRIPTION
This PR adds the LIST_SNAP uzfs ioctl implementation.
For command `zfs listsnap <dataset>`, output will be in json format as:
```
vitta@vitta-laptop:~/openebs/lzfs$ ./cmd/zfs/zfs listsnap pool1/ds0 | jq
{
  "name": "pool1/ds0",
  "snaplist": {
    "istgt1": null,
    "snap4": null,
    "istgt2": null,
    "snap1": null,
    "snap2": null,
    "istgt3": null,
    "snap3": null
  }
}
```

This will NOT list the snapshots created through 'zfs snapshot' until the zrepl is restarted. However, it lists the snapshots created through istgt iscsi target.

This command implementation reads the snapshot list from disk once and caches the list. This cache will be updated with snapshot name for every SNAP_CREATE command from istgt. This cache will be served for every trigger of this ioctl.

Working on testcases.