### PR TITLE
chore(build): trigger downstream repo release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,9 +74,27 @@ install:
     - cd ..
     - cd cstor
 script:
-    export FIO_SRCDIR=$PWD/../fio;
-    sudo bash ./print_debug_info.sh &
-    sudo bash ../libcstor/tests/cstor/script/test_uzfs.sh -T all || travis_terminate 1;
+    - export FIO_SRCDIR=$PWD/../fio;
+    - sudo bash ./print_debug_info.sh &
+    - sudo bash ../libcstor/tests/cstor/script/test_uzfs.sh -T all || travis_terminate 1;
+    # If this build is running due to travis release tag, then
+    # go ahead and tag the dependent repo.
+    #  
+    # $TRAVIS_BRANCH contains the same value as $TRAVIS_TAG.
+    # Example: 1.9.0-RC1 tag and 1.9.0-RC1 branch. 
+    # OpenEBS release are done from branches named as v1.9.x. 
+    # Convert the TRAVIS_TAG to the corresponding release branch.
+    # 
+    # Allow for building forked openebs pipelines. 
+    # Tag the downstream repos under current repo org. 
+    - if [ -z $REPO_ORG ]; then
+        REPO_ORG=$(echo "$TRAVIS_REPO_SLUG" | cut -d'/' -f1);
+        export REPO_ORG;
+      fi
+    - if [ ! -z $TRAVIS_TAG ] && [ "$TRAVIS_REPO_SLUG" == "$REPO_ORG/libcstor" ]; then
+        REL_BRANCH=$(echo v$(echo "$TRAVIS_TAG" | cut -d'-' -f1 | rev | cut -d'.' -f2- | rev).x) ;
+        ./buildscripts/git-release "$REPO_ORG/cstor" "$TRAVIS_TAG" "$REL_BRANCH" || travis_terminate 1;
+      fi
 after_failure:
     - find /var/tmp/test_results/current/log -type f -name '*' -printf "%f\n" -exec cut -c -$CSTOR_TEST_TRAVIS_LOG_MAX_LENGTH {} \;
 after_success:

--- a/buildscripts/git-release
+++ b/buildscripts/git-release
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Copyright 2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+if [ "$#" -ne 3 ]; then
+    echo "Error: Unable to create a new release. Missing required input."
+    echo "Usage: $0 <github org/repo> <tag-name> <branch-name>"
+    echo "Example: $0 kmova/bootstrap v1.0.0 master"
+    exit 1
+fi
+
+C_GIT_URL=$(echo "https://api.github.com/repos/$1/releases")
+C_GIT_TAG_NAME=$2
+C_GIT_TAG_BRANCH=$3
+
+if [ -z ${GIT_NAME} ];
+then
+  echo "Error: Environment variable GIT_NAME not found. Please set it to proceed.";
+  echo "GIT_NAME should be a valid GitHub username.";
+  exit 1
+fi
+
+if [ -z ${GIT_TOKEN} ];
+then
+  echo "Error: Environment variable GIT_TOKEN not found. Please set it to proceed.";
+  echo "GIT_TOKEN should be a valid GitHub token associated with GitHub username.";
+  echo "GIT_TOKEN should be configured with required permissions to create new release.";
+  exit 1
+fi
+
+RELEASE_CREATE_JSON=$(echo \
+{ \
+ \"tag_name\":\"${C_GIT_TAG_NAME}\", \
+ \"target_commitish\":\"${C_GIT_TAG_BRANCH}\", \
+ \"name\":\"${C_GIT_TAG_NAME}\", \
+ \"body\":\"Release created via $0\", \
+ \"draft\":false, \
+ \"prerelease\":false \
+} \
+)
+
+#delete the temporary response file that might 
+#have been left around by previous run of the command
+#using a fixed name means that this script 
+#is not thread safe. only one execution is permitted 
+#at a time.
+TEMP_RESP_FILE=temp-curl-response.txt
+rm -rf ${TEMP_RESP_FILE}
+
+response_code=$(curl -u ${GIT_NAME}:${GIT_TOKEN} \
+ -w "%{http_code}" \
+ --silent \
+ --output ${TEMP_RESP_FILE} \
+ --url ${C_GIT_URL} \
+ --request POST --header 'content-type: application/json' \
+ --data "$RELEASE_CREATE_JSON")
+
+#When embedding this script in other scripts like travis, 
+#success responses like 200 can mean error. rc_code maps
+#the responses to either success (0) or error (1)
+rc_code=0
+
+#Github returns 201 Created on successfully creating a new release
+#201 means the request has been fulfilled and has resulted in one 
+#or more new resources being created.
+if [ $response_code != "201" ]; then
+    echo "Error: Unable to create release. See below response for more details"
+    #The GitHub error response is pretty well formatted.
+    #Printing the body gives all the details to fix the errors
+    #Sample response when the branch already exists looks like this:
+    #{
+    #  "message": "Validation Failed",
+    #  "errors": [
+    #    {
+    #      "resource": "Release",
+    #      "code": "already_exists",
+    #      "field": "tag_name"
+    #    }
+    #  ],
+    #  "documentation_url": "https://developer.github.com/v3/repos/releases/#create-a-release"
+    #}
+    rc_code=1
+else
+    #Note. In case of success, lots of details of returned, but just 
+    #knowing that creation worked is all that matters now.
+    echo "Successfully tagged $1 with release tag ${C_GIT_TAG_NAME} on branch ${C_GIT_TAG_BRANCH}"
+fi
+cat ${TEMP_RESP_FILE}
+
+#delete the temporary response file
+rm -rf ${TEMP_RESP_FILE}
+
+exit ${rc_code}


### PR DESCRIPTION
cStor code base is split across multiple repos.

For releasing cstor code, multiple repo's need
to be tagged in a certain order.

This fix will help to trigger the release
on the downstream repo. In this case, after
releasing openebs/libcstor, openebs/cstor needs
to be tagged.

Note: made a change to travis script section to
convert commands into an array. Without 
this change, was unable to add new commands.

Signed-off-by: kmova <kiran.mova@mayadata.io>
