### PR TITLE
cherry-pick(refact,build): enabling build for release branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: required
 branches:
   only:
     - master
+    - /^\d+\.\d+(\.\d+)?(-\S*)?$/
+    - /^v\d+\.\d+(\.\S*)?$/
 env:
   global:
     # Travis limits maximum log size, we have to cut tests output


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
As of now Travis build is triggered on master branch only, not on release branch. This PR address this issue.

**What this PR does?**:
This PR enables travis build for release branch.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered and commands you used for testing with logs:**


**Any additional information for your reviewer?**:
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

Signed-off-by: mayank <mayank.patel@mayadata.io>
