### PR TITLE
fix(travis): add suffix to single arch image pushed by travis

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -81,7 +81,7 @@ DBUILD_ARGS="--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=
 
 
 if [ "${ARCH}" = "x86_64" ]; then
-	REPO_NAME="$IMAGE_ORG/cstor-base"
+	REPO_NAME="$IMAGE_ORG/cstor-base-amd64"
 	DOCKERFILE_BASE="Dockerfile.base"
 	DOCKERFILE="Dockerfile"
 elif [ "${ARCH}" = "aarch64" ]; then


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**What this PR does?**:
This PR adds the suffix amd64 to the cstor base image built in travis to avoid pushing on the multi-arch builds in action.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
