### PR TITLE
fix(uzfs): Fix zc_nvlist_dst buffer allocation when ioctl is ZFS_IOC_ERROR_LOG

### DIFF
--- a/changelogs/unreleased/82-sgielen
+++ b/changelogs/unreleased/82-sgielen
@@ -1,0 +1,1 @@
+Fix zc_nvlist_dst buffer allocation when ioctl is ZFS_IOC_ERROR_LOG.

--- a/src/libuzfs_handle.c
+++ b/src/libuzfs_handle.c
@@ -55,7 +55,11 @@ static int inline uzfs_ioctl_init(uzfs_ioctl_t *cmd, zfs_cmd_t *zc)
 		zc->zc_nvlist_src = (uint64_t)ptr;
 	}
 	if (zc->zc_nvlist_dst_size) {
-		ptr = malloc(zc->zc_nvlist_dst_size);
+		uint64_t alloc_size = zc->zc_nvlist_dst_size;
+		if (cmd->ioc_num == ZFS_IOC_ERROR_LOG) {
+			alloc_size *= sizeof (zbookmark_phys_t);
+		}
+		ptr = malloc(alloc_size);
 		if (ptr == NULL)
 			goto err;
 		zc->zc_nvlist_dst = (uint64_t)ptr;


### PR DESCRIPTION
Normally, when the ZFS client/userland performs an ioctl, zc_nvlist_dst_size
refers to the amount of bytes that should be allocated for zc_nvlist_dst.
However, for ZFS_IOC_ERROR_LOG specifically, zc_nvlist_dst_size refers to the
amount of error log objects (zbookmark_phys_t) that must be written into
zc_nvlist_dst. When allocating memory for the zc_nvlist_dst, take this
exception into account. This fixes a crash when retrieving a nonempty ZFS error
log.

Tested by applying to my running version of zrepl (v2.1.0) which has 17 errors in
the log. Before this fix, the crash was 100% reproducible. After this fix the crash
no longer occurs and zrepl is working normally.

**Checklist:**
- [X] Fixes https://github.com/openebs/openebs/issues/3346
- [X] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: