### PR TITLE
refact(tests): remove logging to /dev/tty

### DIFF
--- a/tests/cstor/script/test_uzfs.sh
+++ b/tests/cstor/script/test_uzfs.sh
@@ -69,7 +69,7 @@ log_must()
 	status=$?
 
 	if [ $status -ne 0 ]; then
-		cat $logfile > /dev/tty 2>&1
+		cat $logfile
 		rm $logfile
 		log_fail $@
 	fi


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
Github actions runners does not have the `/dev/tty` device and uzfs tests used it to write logs. This caused the workflow to fail. 
By removing logging to `/dev/tty` this failure can be fixed.

**What this PR does?**:
- remove logging to /dev/tty in uzfs tests

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered and commands you used for testing with logs:**


**Any additional information for your reviewer?**:
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: